### PR TITLE
[d0528r0] Update has_padding_bits wording.

### DIFF
--- a/source/D0528r0.bs
+++ b/source/D0528r0.bs
@@ -203,7 +203,7 @@ has_unique_object_representations_v<T>` on the compare-and-exchange members of
 `std::atomic<T>` would—among other things—forbid using compare-and-exchange on
 complex numbers. The authors believe this is unacceptable.
 
-Standards Can Only Be Understood Backward, they Must Lived Forward {#life}
+Standards Can Only Be Understood Backward, they Must Be Lived Forward {#life}
 ------------------------------------------------------------------
 
 We find ourselves unable to use `has_unique_object_representations`, which was

--- a/source/D0528r0.bs
+++ b/source/D0528r0.bs
@@ -284,8 +284,19 @@ Add the following paragraph:
     `has_padding_bits<T>::value` shall be satisfied if and only if:</ins>
 
   * <ins>`T` is trivially copyable, and</ins>
-  * <ins>the object representation of any object of type `T` contains no bits
-    which do not participate in its value representation.</ins>
+  * <ins>there exists at least one bit in the object representations of an
+    object of type `T` which never participates in the value representation.
+    </ins>
+    
+</blockquote>
+    
+Or alternatively for the 2nd bullet:
+
+<blockquote>
+
+  * <ins>given two objects of type `T`, for each bit in their object
+    representations that bit does not participate in their value
+    representations.</ins>
 
 </blockquote>
 


### PR DESCRIPTION
The previous wording would exclude floating point on x86 because it was
looking for any case where there were "padding" bits. The updated wording
looks for bits which are always padding.