### PR TITLE
add second feature test macro

### DIFF
--- a/source/D0995r0.bs
+++ b/source/D0995r0.bs
@@ -435,4 +435,7 @@ template <class T>
 
 </blockquote>
 
-The ``__cpp_lib_atomic_flag_test`` feature test macro should be added.
+Two feature test macros should be added:
+
+  * ``__cpp_lib_atomic_flag_test`` implies the improvements to `atomic_flag` are available.
+  * ``__cpp_lib_atomic_lock_free_test`` implies `atomic_signed_lock_free` and `atomic_unsigned_lock_free` types are defined.

--- a/source/D0995r0.bs
+++ b/source/D0995r0.bs
@@ -438,4 +438,4 @@ template <class T>
 Two feature test macros should be added:
 
   * ``__cpp_lib_atomic_flag_test`` implies the improvements to `atomic_flag` are available.
-  * ``__cpp_lib_atomic_lock_free_test`` implies `atomic_signed_lock_free` and `atomic_unsigned_lock_free` types are defined.
+  * ``__cpp_lib_atomic_lock_free_type_aliases`` implies `atomic_signed_lock_free` and `atomic_unsigned_lock_free` types are defined.


### PR DESCRIPTION
Since we explicitly allow implementations to provide-or-not-provide the types, a macro seems appropriate