### PR TITLE
Fix typo in Math.signbit spec

### DIFF
--- a/source/Math.signbit.bs
+++ b/source/Math.signbit.bs
@@ -74,7 +74,7 @@ zero. While the specification is silent on NaN,
 [the implementation](https://golang.org/src/math/signbit.go) clearly extracts the
 sign bit regardless of NaN-ness.
 
-`Math.sign` {#sign}
+`Math.sign(x)` {#sign}
 -----------
 
 JavaScript provides `Math.sign` which is specified as follows:
@@ -106,9 +106,9 @@ Given existing precedent as well as common hardware support, we propose adding
 
 Returns whether the sign bit of `x` is set.
 
-1. If `n` is `NaN`, the result is `false`.
-1. If `n` is `-0`, the result is `true`.
-1. If `n` is negative, the result is `true`.
+1. If `x` is `NaN`, the result is `false`.
+1. If `x` is `-0`, the result is `true`.
+1. If `x` is negative, the result is `true`.
 1. Otherwise, the result is `false`.
 
   Note: The "Function Properties of the Math Object" section already states:


### PR DESCRIPTION
Also added `x` argument to `Math.sign` so it should make it clear where `x` did come from (same as in `Math.signbit` and in [ECMAScript spec](
https://tc39.github.io/ecma262/#sec-math.sign))