### PR TITLE
fix: P1482r0 editor mail addresses for Bikeshed

### DIFF
--- a/source/P1482r0.bs
+++ b/source/P1482r0.bs
@@ -7,8 +7,8 @@ Status: P
 Group: WG21
 URL: http://wg21.link/P1482R0
 !Source: <a href="https://github.com/jfbastien/papers/blob/master/source/P1482R0.bs">github.com/jfbastien/papers/blob/master/source/P1482R0.bs</a>
-Editor: Bruno Cardoso Lopes, Apple, <blopes@apple.com>
-Editor: Michael Spencer, Apple, <michael_spencer@apple.com>
+Editor: Bruno Cardoso Lopes, Apple, blopes@apple.com
+Editor: Michael Spencer, Apple, michael_spencer@apple.com
 Editor: JF Bastien, Apple, jfbastien@apple.com
 No abstract: true
 Date: 2019-02-08


### PR DESCRIPTION
Bikeshed chokes on the brakets around the addresses when creating the mailto links